### PR TITLE
Fix properties added by NuGet package PowerShell script being encoded

### DIFF
--- a/src/AddIns/Misc/PackageManagement/Project/Src/Scripting/MSBuildProjectPropertiesMerger.cs
+++ b/src/AddIns/Misc/PackageManagement/Project/Src/Scripting/MSBuildProjectPropertiesMerger.cs
@@ -93,7 +93,7 @@ namespace ICSharpCode.PackageManagement.Scripting
 		
 		void SetPropertyInSharpDevelopProject(ProjectPropertyElement msbuildProjectProperty)
 		{
-			sharpDevelopProject.SetProperty(msbuildProjectProperty.Name, msbuildProjectProperty.Value);
+			sharpDevelopProject.SetProperty(msbuildProjectProperty.Name, msbuildProjectProperty.Value, treatPropertyValueAsLiteral: false);
 		}
 		
 		bool HasMSBuildProjectPropertyBeenUpdated(ProjectPropertyElement msbuildProjectProperty, ProjectPropertyElement sharpDevelopProjectProperty)

--- a/src/AddIns/Misc/PackageManagement/Test/Src/Scripting/MSBuildProjectPropertiesMergerTests.cs
+++ b/src/AddIns/Misc/PackageManagement/Test/Src/Scripting/MSBuildProjectPropertiesMergerTests.cs
@@ -260,5 +260,17 @@ namespace PackageManagement.Tests.Scripting
 			
 			Assert.IsFalse(propertiesMerger.Result.AnyPropertiesChanged());
 		}
+		
+		[Test]
+		public void Merge_MSBuildProjectHasNewPropertyAddedWithEncodableCharacters_PropertyAddedToSharpDevelopProjectWithoutEncodingCharacters()
+		{
+			var propertyGroup = msbuildProject.Xml.AddPropertyGroup();
+			propertyGroup.SetProperty("Test", "$(Value)");
+			
+			Merge();
+			
+			string value = sharpDevelopProject.GetUnevalatedProperty("Test");
+			Assert.AreEqual("$(Value)", value);
+		}
 	}
 }


### PR DESCRIPTION
The SlowCheetah NuGet package uses the MSBuild API to directly modify
the MSBuild project file stored in memory in MSBuild's
GlobalProjectCollection. It adds properties that contain special
MSBuild characters, for example $( ). When SharpDevelop was merging
these new properties back into the project file on disk it was using
MSBuild to encode them so the wrong values were added. Now the
property values are not encoded.